### PR TITLE
feat: add infra-management.yaml

### DIFF
--- a/data/infra-management.yaml
+++ b/data/infra-management.yaml
@@ -1,0 +1,13 @@
+- name: virt-manager
+  url: https://github.com/virt-manager/virt-manager
+- name: kube-virt
+  url: https://github.com/kubevirt/kubevirt
+- name: openstack
+  url: https://www.openstack.org
+- name: esxi
+  url: https://www.vmware.com/products/esxi-and-esx.html
+- name: unraid
+  url: https://unraid.net
+- name: proxmox
+  url: https://www.proxmox.com
+  


### PR DESCRIPTION
Some usable virtual infra managers(hypervisor/ hypervisor manager)

Didn’t put kvm/qemu/lib-virt though, as tended to provide more out-of-box, self contained tools rather than libs.