### PR TITLE
Update syncing.yaml - update URL for Firefox Sync Server

### DIFF
--- a/data/syncing.yaml
+++ b/data/syncing.yaml
@@ -8,7 +8,7 @@
   url: 'https://github.com/Kozea/Radicale'
 
 - name: Firefox Sync Server
-  url: https://github.com/mozilla-services/syncserver
+  url: https://github.com/mozilla-services/syncstorage-rs
 
 - name: xBrowserSync
   url: https://github.com/xbrowsersync/app


### PR DESCRIPTION
Updates URL for Firefox Sync Server

Current: url: https://github.com/mozilla-services/syncserver

Proposed: url: https://github.com/mozilla-services/syncstorage-rs

Current URL points to a project that is deprecated/no longer maintained.