### PR TITLE
refactor: update bunkerized-nginx name to BunkerWeb

### DIFF
--- a/data/security.yaml
+++ b/data/security.yaml
@@ -31,7 +31,7 @@
 - name: OpenCTI
   url: https://github.com/OpenCTI-Platform/opencti
 
-- name: bunkerized-nginx
+- name: BunkerWeb
   url: https://github.com/bunkerity/bunkerweb
 
 - name: TheHive


### PR DESCRIPTION
### Description

This PR updates the listing for `bunkerized-nginx` to use its new and official name, `BunkerWeb`.

### Changes made
* Updated `data/security.yaml` to replace the outdated project name.
* Ran `pnpm build` to successfully regenerate `README.md` and fetch the updated badges. 

### Validation
Verified that the build task ran successfully and that the changes correctly cascade into the generated `README.md` table without breaking formatting. 