### PR TITLE
Add NDU to networking category

### DIFF
--- a/data/networking.yaml
+++ b/data/networking.yaml
@@ -33,3 +33,6 @@
 
 - name: Squid
   url: https://github.com/squid-cache/squid
+
+- name: NDU
+  url: https://github.com/TursiThePanda/NDU


### PR DESCRIPTION
Adds [NDU](https://github.com/TursiThePanda/NDU) — a self-hosted home network topology viewer.

NDU scans the LAN and correlates live data from MikroTik / OPNsense / UniFi / Pi-hole / OpenWRT into a single topology map, showing every device, which AP or switch port it sits on, its VLAN, and its connection type. AGPL v3. Runs on Raspberry Pi or Docker (multi-arch image on GHCR).

Appended to `data/networking.yaml`.