### PR TITLE
Add HomeLab Monitor to Monitoring section

### DIFF
--- a/data/monitoring.yaml
+++ b/data/monitoring.yaml
@@ -60,3 +60,6 @@
 
 - name: highlight.io
   url: https://github.com/highlight/highlight
+
+- name: HomeLab Monitor
+  url: 'https://github.com/SikamikanikoBG/homelab-monitor'


### PR DESCRIPTION
HomeLab Monitor is a self-hosted dashboard that runs as a single Docker container and covers per-container GPU/VRAM attribution (which container is actually holding the card), Docker health, systemd service status, host vitals, and multi-machine checks over SSH — all from one page. Built it for my own home lab and have been running it for a few months.

Fits the monitoring section because it's plug-and-play (no Prometheus/Grafana stack, no agents), MIT licensed, and aimed at home lab setups specifically. The GPU-to-container mapping is the part I find genuinely useful when running local LLMs next to everything else.