### PR TITLE
Add SubTrackr to Finance

### DIFF
--- a/data/finance.yaml
+++ b/data/finance.yaml
@@ -18,3 +18,6 @@
 
 - name: ezBookkeeping
   url: https://github.com/mayswind/ezbookkeeping
+
+- name: SubTrackr
+  url: https://github.com/bscott/subtrackr


### PR DESCRIPTION
Adds [SubTrackr](https://github.com/bscott/subtrackr) to the **Finance** category.

SubTrackr is a privacy-focused, fully self-hostable subscription tracker (Go) with reminders, custom categories, currency conversion, and charts — similar in spirit to Wallos. It's open source, actively maintained, and currently at ~446 stars.

Only `data/finance.yaml` is edited

Thank you 