### PR TITLE
Add Hivekeep to AI

### DIFF
--- a/data/a-i.yaml
+++ b/data/a-i.yaml
@@ -60,3 +60,6 @@
 
 - name: 1Backend
   url: https://github.com/1backend/1backend
+
+- name: Hivekeep
+  url: 'https://github.com/MarlBurroW/hivekeep'


### PR DESCRIPTION
Adds Hivekeep to data/a-i.yaml (AI category), following the existing { name, url } format. The README is generated from the YAML data per AGENTS.md, so I only edited the source file.

Hivekeep is a self-hosted, MIT-licensed platform to run a team of specialized AI agents with persistent memory and a web UI; single container (Bun + SQLite), reachable over Telegram/Slack/Discord/Matrix. Great fit for a homelab.

https://github.com/MarlBurroW/hivekeep

Disclosure: I am the author. Thanks!