### PR TITLE
Add Tura to AI

### DIFF
--- a/data/a-i.yaml
+++ b/data/a-i.yaml
@@ -60,3 +60,6 @@
 
 - name: 1Backend
   url: https://github.com/1backend/1backend
+
+- name: Tura
+  url: https://github.com/Tura-AI/tura


### PR DESCRIPTION
## Summary

Adds [Tura](https://github.com/Tura-AI/tura) to the AI app catalog through the repository's source file, `data/a-i.yaml`.

## Why it fits

Tura is an AGPL-3.0 local coding agent that runs on the user's machine, supports Ollama and custom OpenAI-compatible providers, and offers CLI, TUI, desktop, and optional web interfaces through its local HTTP/SSE gateway. It gives homelab users a local-first way to automate repository work without requiring a hosted coding-agent service.

## Validation

- `pnpm lint`
- `pnpm build` (Tura appears in the generated AI table; the build exits successfully)
- Confirmed there is no existing Tura entry or open submission

Disclosure: I am affiliated with the Tura project.