### PR TITLE
Add NSL.SH to Networking section

### DIFF
--- a/data/networking.yaml
+++ b/data/networking.yaml
@@ -33,3 +33,7 @@
 
 - name: Squid
   url: https://github.com/squid-cache/squid
+
+- name: NSL.SH
+  url: 'https://github.com/Yundera/mesh-router-root'
+  description: 'Free domain routing for self-hosted services with automatic HTTPS behind NAT. https://nsl.sh'


### PR DESCRIPTION
NSL.SH is a free domain routing service for self-hosted setups. It gives you a public subdomain with automatic HTTPS and works behind NAT without port forwarding. Built on WireGuard and Caddy.

https://nsl.sh
