### PR TITLE
Add FluxDown to Download category

### DIFF
--- a/data/download.yaml
+++ b/data/download.yaml
@@ -10,6 +10,9 @@
 - name: Deluge
   url: 'https://github.com/deluge-torrent/deluge'
 
+- name: FluxDown
+  url: 'https://github.com/zerx-lab/FluxDown'
+
 - name: Mylar3
   url: 'https://github.com/mylar3/mylar3'
 


### PR DESCRIPTION
Adds FluxDown to `data/download.yaml`, inserted alphabetically between Deluge and Mylar3.

FluxDown is a multi-protocol download manager built on a Rust/Tokio engine. It handles HTTP/HTTPS, FTP, BitTorrent (DHT + magnet), eD2K/Kad, HLS and DASH, with dynamic file segmentation, token-bucket rate limiting and SQLite-backed resume across restarts.

For homelab use there is a headless server (`fluxdown-server`) that serves its own web UI on port 17800, so it runs standalone on a NAS or VPS without the desktop client. The image is published at `ghcr.io/zerx-lab/fluxdown-server` for linux/amd64 and linux/arm64. It also exposes an aria2-compatible JSON-RPC API, so existing aria2 front-ends work against it unmodified.

- Repo: https://github.com/zerx-lab/FluxDown
- Site: https://fluxdown.zerx.dev
- License: AGPL-3.0

I only touched `data/download.yaml` and left the generated `README.md` alone, per AGENTS.md. `pnpm exec eslint data/download.yaml` passes.

Disclosure: I maintain FluxDown.