### PR TITLE
Add Lynavo Drive to Photo Management

### DIFF
--- a/data/photo-management.yaml
+++ b/data/photo-management.yaml
@@ -1,6 +1,9 @@
 - name: LibrePhotos
   url: 'https://github.com/LibrePhotos/librephotos'
 
+- name: Lynavo Drive
+  url: 'https://github.com/Lynavo/lynavo-drive'
+
 - name: immich
   url: 'https://github.com/immich-app/immich'
 


### PR DESCRIPTION
Adds Lynavo Drive to the Photo Management category.

**An open-source alternative to iCloud and Google Photos**

Lynavo Drive provides automatic incremental photo and video sync from iOS and Android to macOS and Windows over the local LAN. The repository is AGPL-3.0 and includes the mobile clients, desktop receiver, local discovery and pairing, and resumable transfer implementation.

Only `data/photo-management.yaml` is changed. The generator and ESLint both completed successfully; generated README churn from live third-party metadata was intentionally left out of this focused PR.

Disclosure: I am affiliated with the Lynavo Drive project.