### PR TITLE
Add CleanArr to Media Management

### DIFF
--- a/data/media-management.yaml
+++ b/data/media-management.yaml
@@ -43,6 +43,9 @@
 - name: Maintainerr
   url: 'https://github.com/jorenn92/Maintainerr'
 
+- name: CleanArr
+  url: 'https://github.com/mambastick/Cleanarr'
+
 - name: Overseerr
   url: 'https://github.com/sct/overseerr'
 


### PR DESCRIPTION
## Summary

Adds [CleanArr](https://github.com/mambastick/Cleanarr) to the Media Management catalog through the repository source file, `data/media-management.yaml`.

## Why it fits

CleanArr is a self-hosted application that listens for Jellyfin deletion events and safely cascades cleanup to Radarr, Sonarr, Jellyseerr, and qBittorrent. It provides dry-run mode, conservative ownership checks, a web interface, Docker Compose support, and Kubernetes manifests.

## Validation

- `pnpm lint`
- `pnpm exec eslint data/media-management.yaml`
- `pnpm build` completed successfully and generated a Media Management entry for CleanArr
- Confirmed that there is no existing CleanArr catalog entry or pull request

The generated `README.md` is intentionally not included in this PR because the repository's master-branch workflow regenerates and publishes it from `data/*.yaml`.

Disclosure: I am the author and maintainer of CleanArr.
