### PR TITLE
Add MyNeS to networking

### DIFF
--- a/data/networking.yaml
+++ b/data/networking.yaml
@@ -33,3 +33,6 @@
 
 - name: Squid
   url: https://github.com/squid-cache/squid
+
+- name: MyNeS
+  url: https://github.com/fxerkan/my_network_scanner


### PR DESCRIPTION
Adds **MyNeS (My Network Scanner)** to `data/networking.yaml`.

- https://github.com/fxerkan/my_network_scanner — MIT, Python + Docker (`amd64` and `arm64`)

A self-hosted LAN scanner and device inventory. It discovers devices over ARP, mDNS/Bonjour, SSDP/UPnP, Matter, Bluetooth LE **and MQTT** — reading retained Zigbee2MQTT / Z-Wave JS / Tasmota topics is the only way to inventory a radio device that has no IP address, so Zigbee bulbs and Z-Wave sensors show up next to the servers. Plus vendor lookup over a 1000+ entry OUI database, topology and graph views, scan history, alerts on new / missing / changed devices, and two-way Home Assistant integration.

Only `data/networking.yaml` is touched; `README.md` is left to the generator per `AGENTS.md`.