### PR TITLE
Add UniFi Reactor to Automation category

### DIFF
--- a/data/automation.yaml
+++ b/data/automation.yaml
@@ -18,3 +18,6 @@
 
 - name: µTask
   url: https://github.com/ovh/utask
+
+- name: UniFi Reactor
+  url: https://github.com/robbeverhelst/unifi-reactor


### PR DESCRIPTION
Adds [UniFi Reactor](https://github.com/robbeverhelst/unifi-reactor) to `data/automation.yaml`.

It is a Kubernetes operator that polls the UniFi Network API and reconciles a cluster against what it observes there — which WAN uplink is live, whether a UniFi UPS is on mains or on battery, PoE headroom, pending firmware — by scaling Deployments, suspending CronJobs, cordoning nodes, or sending a notification. The case it was built for is the homelab one: the power drops, the UPS starts counting down its runtime, and the cluster spends it transcoding video.

Apache 2.0. One static Go binary in a distroless image, multi-arch, no database and no UI. Installed with a Helm chart or a single manifest; the image and the chart are both cosign-signed from the release workflow.

Entry added in the same shape as the rest of the file (`name` and `url` only), so the description and badges come from repository metadata at build time. `README.md` is left alone since it is generated by `pnpm build`.