### PR TITLE
Add Paperpack to finance

### DIFF
--- a/data/finance.yaml
+++ b/data/finance.yaml
@@ -18,3 +18,6 @@
 
 - name: ezBookkeeping
   url: https://github.com/mayswind/ezbookkeeping
+
+- name: Paperpack
+  url: https://github.com/ChangkeunJ/paperpack


### PR DESCRIPTION
Adds Paperpack: an open-source (MIT) calculator for Australian working holiday maker tax and the departing superannuation payment. It is a fully static site, so self-hosting is any web server pointed at the built files; all computation runs client-side and no user input leaves the browser. Live copy at https://paperpack-7v7.pages.dev/ for a look before merging.

Disclosure: I am the author.