### PR TITLE
Add WebSSH to Development

### DIFF
--- a/data/development.yaml
+++ b/data/development.yaml
@@ -37,6 +37,9 @@
 - name: Sshwifty
   url: 'https://github.com/nirui/sshwifty'
 
+- name: WebSSH
+  url: 'https://github.com/bifrost0x/webssh'
+
 - name: Planka
   url: 'https://github.com/plankanban/planka'
 


### PR DESCRIPTION
Adds [WebSSH](https://github.com/bifrost0x/webssh) to the Development category.

WebSSH is a self-hosted, browser-based SSH client designed for homelab and infrastructure administration. It provides convenient web access to SSH hosts and can be deployed using Docker.

The entry is added to `data/development.yaml` alongside similar browser-based administration tools. `README.md` is left unchanged because it is generated from the YAML source data.

Disclosure: I am the maintainer of WebSSH.